### PR TITLE
Fix eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,7 +106,7 @@ module.exports = {
         bracketSpacing: true,
         printWidth: 80,
         semi: true,
-        singleQuote: true,
+        doubleQuote: true,
         trailingComma: "all",
         useTabs: false
       }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
+it("renders without crashing", () => {
+  const div = document.createElement("div");
   ReactDOM.render(<App />, div);
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import React from "react";
+import logo from "./logo.svg";
+import "./App.css";
 
 const App: React.FC = () => {
   return (


### PR DESCRIPTION
ファイル保存のたびにPrettierが ' と " を入れ替える問題を解消。
インポートしているルールのどれかと、直接rulesに書いているルールが衝突していた様子。
どのインポートルールが " なのか特定するのは大変なので、rulesを書き換えて " に寄せた。